### PR TITLE
Fix: Correct syntax error in CompressionSettings component

### DIFF
--- a/src/components/CompressionSettings.tsx
+++ b/src/components/CompressionSettings.tsx
@@ -172,7 +172,7 @@ export function CompressionSettings({ onSettingsChange }: CompressionSettingsPro
                 step="100"
               />
             </div>
-            )}
+            )
 
           <div>
             <label htmlFor="audioQuality" className="block text-sm font-medium mb-1 text-gray-700 dark:text-gray-300">


### PR DESCRIPTION
An extraneous closing curly brace was present after the conditional rendering block for the bitrate input field within the CompressionSettings component. This caused a Babel parsing error during the build process.

This commit removes the unnecessary curly brace, resolving the syntax issue.